### PR TITLE
Fix divide-by-zero error in hydrosnow

### DIFF
--- a/hydrosnow.c
+++ b/hydrosnow.c
@@ -245,7 +245,7 @@ hydrosnow ()
   Mout = Mgw + Mnival + Enivalannual * totalarea[ep] + Msnowend + Mwrapout;
   Minput = MPnival + Mwrapin + Msnowstart;
 
-  if ((fabs (Mout - Minput) / Minput) > masscheck)
+  if (Minput > 0.0 && (fabs (Mout - Minput) / Minput) > masscheck)
     {
       fprintf (stderr, "\nERROR in HydroSnow: \n");
       fprintf (stderr, "  Mass Balance error: Mout != Minput \n\n");


### PR DESCRIPTION
This pull request fixes a divide-by-zero error in *hydrosnow* that caused a segmentation fault or floating point exception, depending on the system. A mass-balance check is done at the end of *hydrosnow* and if `Minput` is zero, which happens to be the denominator, a floating-point error may be triggered.